### PR TITLE
Add mapillary coveraage date as json

### DIFF
--- a/output/meta.json
+++ b/output/meta.json
@@ -1,0 +1,3 @@
+{
+  "mapillary_coverage_date": "2025-10-07",
+}


### PR DESCRIPTION
This exposes the date of the last mapillary run in a format that other apps can consume easily.
The file as to be updated manually for now, whenever the README is also updated.

See also https://github.com/vizsim/mapillary_coverage/pull/4 for some more context on how to maybe automate this.